### PR TITLE
fix(array): fix set() with a path going through an array

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -118,7 +118,7 @@ function set(base, path, value, { withArrays, sameValue }) {
     return [
       ...currentBase.slice(0, key),
       set(nextBase(currentBase, key, nextKey, withArrays), path.slice(1), value, { withArrays, sameValue }),
-      ...currentBase.slice(key + 1),
+      ...currentBase.slice(parseInt(key) + 1),
     ];
   }
 

--- a/tests/set.spec.js
+++ b/tests/set.spec.js
@@ -277,4 +277,23 @@ describe('multiple set', () => {
 
     expect(set(base, path, value, { sameValue: true })).toEqual(expected);
   });
+
+  it('should set objects through an array', () => {
+    const base = freeze({
+      a: {
+        b: [{ id: 1, next: 1 }, { id: 2, next: 1 }, { id: 3, next: 1 }, { id: 4, next: 1 }],
+      },
+    });
+
+    const expected = {
+      a: {
+        b: [{ id: 1, next: 1 }, { id: 2, next: 2 }, { id: 3, next: 1 }, { id: 4, next: 1 }],
+      },
+    };
+
+    const path = 'a.b.1.next';
+    const value = 2;
+
+    expect(set(base, path, value)).toEqual(expected);
+  });
 });


### PR DESCRIPTION
When we use `set()` with a path that contain an array, the array reconstruction can miss some elements.

For example, considering having this base object:

```js
{
  a: {
    b: [{ id: 1, next: 1 }, { id: 2, next: 1 }, { id: 3, next: 1 }, { id: 4, next: 1 }],
  },
};
```

If we want to update the path `a.b.0.next` there was no problem, but if we update the path `a.b.1.next` we lost the thrid and forth elements.

<img width="657" alt="Capture d’écran 2022-03-21 à 13 32 43" src="https://user-images.githubusercontent.com/415891/159268799-06bfd946-736e-42d4-9db8-aa3e64ee01c3.png">

This happens when rebuilding the array. Here is an extract of the library code:

```js
return [
  ...currentBase.slice(0, key),
  set(currentBase[key]),
   ...currentBase.slice(key + 1),
];
```

In our case, `key + 1` is evaluted to `11` since key was a string. So we lost the values from 2 to 10.

My PR add the described test, and a `parseInt()` to avoid this problem.